### PR TITLE
Fix bug of switch button with source language spinner set as auto

### DIFF
--- a/app/src/androidTest/java/com/github/sdpsharelook/TranslateActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpsharelook/TranslateActivityTest.kt
@@ -99,6 +99,12 @@ class TranslateActivityTest {
         delay(1000)
     }
 
+    @Test
+    fun testCannotSwitchWhenSourceLanguageIsAuto() {
+        selectSourceLanguage("auto")
+        selectTargetLanguage("en")
+        onView(withId(R.id.buttonSwitchLang)).check(matches(not(isEnabled())))
+    }
         
     @Test
     fun testSwitchSourceOrTargetLanguageMustRunTranslation() {


### PR DESCRIPTION
Fix bug when source language spinner was set to auto, we could press the switch button. It's no longer possible. Also, using binding instead of all the findViewByID as Edouard has explained to me.